### PR TITLE
Update ahpy.py

### DIFF
--- a/ahpy/ahpy.py
+++ b/ahpy/ahpy.py
@@ -148,7 +148,7 @@ class Compare:
         self._matrix = np.ones((self._size, self._size))
         for pair, value in self._pairs.items():
             location = tuple(self._elements.index(elements) for elements in pair)
-            self._matrix.itemset(location, value)
+            self._matrix[location] = value
 
     def _build_normalized_matrix(self):
         """


### PR DESCRIPTION
Replace deprecated `itemset()` for NumPy 2.0 compatibility.

### Problem

Using `ahpy.Compare()` with NumPy 2.0+ causes:

AttributeError: `itemset` was removed from the ndarray class in NumPy 2.0.

### Cause

The method `.itemset()` was removed in NumPy 2.0. This breaks compatibility.

### Fix

Modify the order of building numpy matrix, i.e. replaced:

```python
self._matrix.itemset(location, value)
```

with:

```python
self._matrix[location] = value
```

This change is backward-compatible and works with both NumPy 1.x and 2.x. Thanks for maintaining this useful package.